### PR TITLE
Update draft.toml

### DIFF
--- a/draft.toml
+++ b/draft.toml
@@ -1,6 +1,6 @@
 [environments]
   [environments.development]
-    name = "Application"
+    name = "application"
     namespace = "default"
     wait = false
     watch = false


### PR DESCRIPTION
This was the blocker; draft enforced lowercasing because of earlier creation of dns name. I'll file an issue with draft; in the meanwhile, keep this value all lowercase, and it builds and pushes fine.